### PR TITLE
Add handling to fix phpstorm paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,8 +61,21 @@ func translateWindowsPathInArgs(windowsPathArgs []string) []string {
 }
 
 var windowsDrivePathPattern = regexp.MustCompile("([[:alpha:]]):\\\\")
+var windowsDrivePathPatternPHPStorm = regexp.MustCompile("([[:alpha:]]):/")
 
 func translateWindowsPathInArg(arg string) string {
+
+	// Fix for PHPStorm Paths in Cross-Environemnt
+	if windowsDrivePathPatternPHPStorm.FindStringIndex(arg) != nil {
+		driveReplaced := windowsDrivePathPatternPHPStorm.ReplaceAllStringFunc(arg, func(drivePath string) string {
+			m := windowsDrivePathPatternPHPStorm.FindStringSubmatch(drivePath)
+			drive := strings.ToLower(m[1])
+			return fmt.Sprintf("/mnt/%s/", drive)
+		})
+		backslashReplaced := strings.Replace(driveReplaced, "\\", "/", -1)
+		return backslashReplaced
+	}
+
 	if windowsDrivePathPattern.FindStringIndex(arg) == nil {
 		return arg
 	}


### PR DESCRIPTION
In cross plattform Windows <=> Linux PHPStorm is often using LInux Path Seperators instead of windows path seperators for windows paths. These paths are not valid in windows nor in wsl linux. To fix this issue the path fixer will also check for phpstorms wrong usage of path seperators. 

Maybe it will help someone. The given code is really not the best cause of simple copy & paste of the origin function. Maybe someone with a better understanding for go could do a cleanup or a generalization.